### PR TITLE
Add model id, PID, rates, and LED sensors to smartport

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1241,6 +1241,10 @@ const clivalue_t valueTable[] = {
     { "telemetry_enable_cap_used",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_CAP_USED),        PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
     { "telemetry_enable_adjustment",      VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_ADJUSTMENT),      PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
     { "telemetry_enable_gov_mode",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_GOV_MODE),        PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
+    { "telemetry_enable_model_id",        VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_MODEL_ID),        PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
+    { "telemetry_enable_pid_profile",     VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_PID_PROFILE),     PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
+    { "telemetry_enable_rates_profile",   VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_RATES_PROFILE),   PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
+    { "telemetry_enable_led_profile",     VAR_UINT32  | MASTER_VALUE | MODE_BITSET, .config.bitpos = LOG2(SENSOR_LED_PROFILE),     PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
 #else
     { "telemetry_enable_sensors",         VAR_UINT32 | MASTER_VALUE, .config.u32Max = SENSOR_ALL, PG_TELEMETRY_CONFIG, offsetof(telemetryConfig_t, enableSensors)},
 #endif

--- a/src/main/pg/telemetry.h
+++ b/src/main/pg/telemetry.h
@@ -48,6 +48,10 @@ typedef enum {
     SENSOR_CAP_USED        = BIT(20),
     SENSOR_ADJUSTMENT      = BIT(21),
     SENSOR_GOV_MODE        = BIT(22),
+    SENSOR_MODEL_ID        = BIT(23),
+    SENSOR_PID_PROFILE     = BIT(24),
+    SENSOR_RATES_PROFILE   = BIT(25),
+    SENSOR_LED_PROFILE     = BIT(26),
 } sensor_e;
 
 typedef enum {

--- a/src/main/telemetry/smartport.c
+++ b/src/main/telemetry/smartport.c
@@ -63,6 +63,7 @@
 #include "io/beeper.h"
 #include "io/gps.h"
 #include "io/serial.h"
+#include "io/ledstrip.h"
 
 #include "msp/msp.h"
 
@@ -132,7 +133,11 @@ enum
     FSSP_DATAID_ADJFUNC    = 0x5110 , // custom
     FSSP_DATAID_ADJVALUE   = 0x5111 , // custom
     FSSP_DATAID_CAP_USED   = 0x5250 ,
-    FSSP_DATAID_GOV_MODE   = 0x5450 , //custom
+    FSSP_DATAID_GOV_MODE   = 0x5450 , // custom
+    FSSP_DATAID_MODEL_ID   = 0x5460 , // custom
+    FSSP_DATAID_PID_PROFILE   = 0x5471 , // custom
+    FSSP_DATAID_RATES_PROFILE = 0x5472 , // custom
+    FSSP_DATAID_LED_PROFILE   = 0x5473 , // custom
 #if defined(USE_ACC)
     FSSP_DATAID_PITCH      = 0x5230 , // custom
     FSSP_DATAID_ROLL       = 0x5240 , // custom
@@ -160,7 +165,7 @@ enum
 };
 
 // if adding more sensors then increase this value (should be equal to the maximum number of ADD_SENSOR calls)
-#define MAX_DATAIDS 25
+#define MAX_DATAIDS 29
 
 static uint16_t frSkyDataIdTable[MAX_DATAIDS];
 
@@ -336,8 +341,24 @@ static void initSmartPortSensors(void)
 
     //prob need configurator option for these?
     if (telemetryIsSensorEnabled(SENSOR_GOV_MODE)) {
-    ADD_SENSOR(FSSP_DATAID_GOV_MODE);
-    }    
+        ADD_SENSOR(FSSP_DATAID_GOV_MODE);
+    }
+
+    if (telemetryIsSensorEnabled(SENSOR_MODEL_ID)) {
+        ADD_SENSOR(FSSP_DATAID_MODEL_ID);
+    }
+
+    if (telemetryIsSensorEnabled(SENSOR_PID_PROFILE)) {
+        ADD_SENSOR(FSSP_DATAID_PID_PROFILE);
+    }
+
+    if (telemetryIsSensorEnabled(SENSOR_RATES_PROFILE)) {
+        ADD_SENSOR(FSSP_DATAID_RATES_PROFILE);
+    }
+
+    if (telemetryIsSensorEnabled(SENSOR_LED_PROFILE)) {
+        ADD_SENSOR(FSSP_DATAID_LED_PROFILE);
+    }
 
     if (telemetryIsSensorEnabled(SENSOR_MODE)) {
         ADD_SENSOR(FSSP_DATAID_T1);
@@ -662,7 +683,23 @@ void processSmartPortTelemetry(smartPortPayload_t *payload, volatile bool *clear
                     smartPortSendPackage(id, getGovernorState());
                 }
                 *clearToSend = false;
-                break;           
+                break;
+            case FSSP_DATAID_MODEL_ID   :
+                smartPortSendPackage(id, pilotConfig()->modelId);
+                *clearToSend = false;
+                break;
+            case FSSP_DATAID_PID_PROFILE :
+                smartPortSendPackage(id, getCurrentPidProfileIndex() + 1);
+                *clearToSend = false;
+                break;
+            case FSSP_DATAID_RATES_PROFILE :
+                smartPortSendPackage(id, getCurrentControlRateProfileIndex() + 1);
+                *clearToSend = false;
+                break;
+            case FSSP_DATAID_LED_PROFILE :
+                smartPortSendPackage(id, getLedProfile() + 1);
+                *clearToSend = false;
+                break;
             case FSSP_DATAID_VFAS       :
                 vfasVoltage = telemetryConfig()->report_cell_voltage ? getBatteryAverageCellVoltage() : getBatteryVoltage();
                 smartPortSendPackage(id, vfasVoltage); // in 0.01V according to SmartPort spec


### PR DESCRIPTION
Add model id, PID profile, rate profile, and LED profile to FrSky telemetry

Adds the following settings which will need toggles in configurator too:

```
telemetry_enable_model_id
telemetry_enable_pid_profile
telemetry_enable_rates_profile
telemetry_enable_led_profile

Allowed values: OFF, ON
Default value: OFF
```